### PR TITLE
Fix instructions requiring terminal resize not rendering

### DIFF
--- a/game/renderer.go
+++ b/game/renderer.go
@@ -65,6 +65,7 @@ func (g *game) Render() {
 	tWidth, tHeight := termbox.Size()
 	if g.Width > tWidth || g.Height > tHeight {
 		renderString(0, 0, []rune("Terminal is too small. Please resize."))
+		termbox.Flush()
 		return
 	}
 


### PR DESCRIPTION
The grid is unable to render if the terminal in which the game is being played has either a height or width smaller than the height or width required by the game.

Prior to this pull request, a message asking the user to resize their terminals when this condition was met was not being rendered on the terminal screen due to the absence of a call to `termbox.Flush`.

As such, this PR sees the addition of a call to `termbox.Flush` before returning from `game.Render`.